### PR TITLE
Preserve aspect ratio in plotmap

### DIFF
--- a/src/OpenStreetMapXPlot.jl
+++ b/src/OpenStreetMapXPlot.jl
@@ -5,7 +5,7 @@ using OpenStreetMapX
 import Plots
 import PyPlot 
 
-export plotmap, addroute!, plot_nodes! #Plotting
+export plotmap, addroute!, plot_nodes!, plot_nodes_as_symbols! #Plotting
 
 include("plot.jl") #plotting
 include("layers.jl") #colors

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -479,3 +479,44 @@ function plot_nodes!(p,m::OpenStreetMapX.MapData,nodeids::Vector{Int};
    end
    p
 end
+"""
+    plot_nodes_as_symbols!(p, m::OpenStreetMapX.MapData, 
+        nodeids::Vector{Int};
+        symbols::Union{String,Vector{String}}="*",
+        colors::Union{String,Vector{String}}=["darkgreen"],
+        km::Bool=false, 
+        fontsize=10) 
+    
+Plots nodes having node identifiers `nodeids` on the plot `p` using map information `m`.
+By default the nodes are plotted with the "*" symbol, however,
+setting the parameter `symbols` to a string will plot all node locations as that string. 
+Setting `symbols` to an array of strings will plot each successive location as the symbol 
+in that position of the array, repeating over the string array if the `symbols` array
+is shorter than the `nodeids` array.
+The `km` parameter can be used to have a kilometer scale of the map instead of meters.
+
+Returns an object that can be used for further plot updates.
+"""
+
+function plot_nodes_as_symbols!(p,m::OpenStreetMapX.MapData,nodeids::Vector{Int};
+		                symbols::Union{String,Vector{String}}="*",
+                                colors::Union{String,Vector{String}}=["darkgreen"],
+                                km::Bool=false, fontsize=10)
+    (length(nodeids) == 0) && return
+    osm_use_pyplot = (p == :osm_use_pyplot)
+    divkm = (isa(m.nodes[nodeids[1]],OpenStreetMapX.ENU) && km) ? 1000.0 : 1.0
+    symbols = typeof(symbols)==String ? [symbols] : symbols
+    colors = typeof(colors)==String ? [colors] : colors
+    for i in 1:length(nodeids)
+        X = OpenStreetMapX.getX(m.nodes[nodeids[i]]) / divkm
+        Y = OpenStreetMapX.getY(m.nodes[nodeids[i]]) / divkm
+        j = (i-1)%length(symbols) + 1
+        k = (i-1)%length(colors) + 1
+        if !osm_use_pyplot
+            Plots.annotate!(p,X,Y,Plots.text(symbols[j],fontsize,Symbol(colors[k])))
+        else
+            PyPlot.text(X,Y,symbols[j],color=colors[k],fontsize=fontsize)
+        end
+   end
+   p
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -322,7 +322,8 @@ end
     
 Plots `roadways` for a given map `m`.
 
-The width will be set to `width` and the height will be set to `height`.
+The width will be set to `width` and the height will be set to `height`. If only one of `width`
+or `height` is set, the other will be set to perserve the aspect ratio of the bounding box.
 The `km` parameter can be used to have a kilometer scale of the map instead of meters.
 
 The default plotting backend is `Plots.jl`, however if the `use_plain_pyplot` 
@@ -332,10 +333,27 @@ is set to `true` than `PyPlot.jl` is used
 Returns an object that can be used for further plot updates.
 
 """
-plotmap(m::OpenStreetMapX.MapData;roadwayStyle = OpenStreetMapXPlot.LAYER_STANDARD, 
-	width::Integer=600, height::Integer=600, km::Bool=false, use_plain_pyplot::Bool=false) = 
-	plotmap(m.nodes, OpenStreetMapX.ENU(m.bounds), roadways=m.roadways,roadwayStyle = roadwayStyle, width=width, height=height, km=km, use_plain_pyplot=use_plain_pyplot)
+function plotmap(m::OpenStreetMapX.MapData;roadwayStyle = OpenStreetMapXPlot.LAYER_STANDARD, 
+	         width::Union{Integer,Nothing}=nothing, height::Union{Integer,Nothing}=nothing, km::Bool=false, use_plain_pyplot::Bool=false)
+     
+    # Set plot aspect ratio to that of bounds (in meters), unless both height and width are specified
+    if width==nothing || height==nothing
+        # Compute aspect ratio
+        aspect_ratio = OpenStreetMapXPlot.aspect_ratio(m.bounds)
 
+        if width==nothing && height==nothing
+            width = 600
+            height = Int(round(width/aspect_ratio))
+        elseif height==nothing
+            height = Int(round(width/aspect_ratio))
+        elseif width==nothing
+            width = Int(round(height*aspect_ratio))
+        end
+    end
+
+    plotmap(m.nodes, OpenStreetMapX.ENU(m.bounds), roadways=m.roadways,roadwayStyle = roadwayStyle,
+            width=width, height=height, km=km, use_plain_pyplot=use_plain_pyplot)
+end
 
 """
     plotmap(m::OpenStreetMapX.Mapaddroute!(p, m::OpenStreetMapX.MapData,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,8 @@ const trk = [LLA(m.bounds.min_y,m.bounds.min_x,0.0), LLA(m.bounds.max_y,m.bounds
 	@test typeof(p) == Plots.Plot{Plots.GRBackend}
 	@test addroute!(p,m,sr1;route_color="red") == p
 	@test plot_nodes!(p,m,[sr1[1],sr1[end]],start_numbering_from=nothing,fontsize=13,color="pink") == p
-	@test addroute!(p,m,trk;route_color="red") == p
+        @test plot_nodes_as_symbols!(p, m, sr1, symbols=["*","+","#"],colors=["red","green","blue"],fontsize=13) == p
+        @test addroute!(p,m,trk;route_color="red") == p
 end
 
 @testset "PyPlot backend" begin
@@ -40,5 +41,6 @@ end
 	@test p == :osm_use_pyplot
 	@test addroute!(p,m,sr1;route_color="red") == p
 	@test plot_nodes!(p,m,[sr1[1],sr1[end]],start_numbering_from=nothing,fontsize=13,color="pink") == p
+        @test plot_nodes_as_symbols!(p, m, sr1, symbols=["*","+","#"],colors=["red","green","blue"],fontsize=13) == p
 	@test addroute!(p,m,trk;route_color="red") == p
 end


### PR DESCRIPTION
Also added plot_nodes_as_symbols!() as an extension to plot_nodes!() to allow node locations to be indicated by arbitrary string symbols.